### PR TITLE
Make installation of java optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Ubuntu 14.04
     <td><tt>''</td></tt>
   </tr>
   <tr>
-    <td><tt>['java']['oracle']['accept_oracle_download_terms']</tt></td>
+    <td><tt>['looker']['install_java']</tt></td>
     <td>Boolean</td>
-    <td>Looker requires Oracle Java, do you accept the terms?</td>
+    <td>Installs oracle java 7. **NOTE:** By setting this to true you accept oracle download terms. See [cookbook/java](https://supermarket.chef.io/cookbooks/java) for details.</td>
     <td><tt>true</td></tt>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Ubuntu 14.04
   <tr>
     <td><tt>['looker']['install_java']</tt></td>
     <td>Boolean</td>
-    <td>Installs oracle java 7. **NOTE:** By setting this to true you accept oracle download terms. See [cookbook/java](https://supermarket.chef.io/cookbooks/java) for details.</td>
+    <td>Installs oracle java 7. By setting this to true you accept oracle download terms. See <a href="https://supermarket.chef.io/cookbooks/java">cookbook/java</a> for details.</td>
     <td><tt>true</td></tt>
   </tr>
 </table>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default['java']['oracle']['accept_oracle_download_terms'] = true
+default['looker']['install_java'] = true
 
 default['looker']['home'] = '/home/looker'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'awesome@shopkeep.com'
 license          'All rights reserved'
 description      'Installs/Configures looker'
 long_description 'Installs/Configures looker'
-version          '0.2.2'
+version          '0.2.3'
 
 depends 'apt'
 depends 'java'

--- a/recipes/_java.rb
+++ b/recipes/_java.rb
@@ -7,7 +7,9 @@
 # All rights reserved - Do Not Redistribute
 #
 
-node.set['java']['install_flavor'] = 'oracle'
-node.set['java']['jdk_version'] = 7
-
-include_recipe 'java'
+if node['looker']['install_java']
+  node.set['java']['oracle']['accept_oracle_download_terms'] = true
+  node.set['java']['install_flavor'] = 'oracle'
+  node.set['java']['jdk_version'] = 7
+  include_recipe('java')
+end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -72,8 +72,23 @@ describe 'looker::default' do
       )
     end
 
-    it 'installs oracle java 7' do
+    it 'installs java' do
       expect(chef_run).to include_recipe('java')
+    end
+
+    context 'when install_java is set to false' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
+          node.set['looker']['run_dir'] = looker_run_dir
+          node.set['looker']['startup_script_url'] = startup_script
+          node.set['looker']['jar_file_url'] = jar_file
+          node.set['looker']['install_java'] = false
+        end.converge(described_recipe)
+      end
+
+      it 'does not installs java' do
+        expect(chef_run).to_not include_recipe('java')
+      end
     end
 
     context 'Installs the looker ohai plugin' do


### PR DESCRIPTION
As per recommended usage of cookbook/java
(https://supermarket.chef.io/cookbooks/java) make installation of
java via java cookbook optional. Update readme to reflect this.