### PR TITLE
Upgrade JDK to 8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,4 @@ gem 'berkshelf'
 
 gem 'test-kitchen'
 gem 'kitchen-vagrant'
+gem 'chef-sugar'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,5 @@ version          '0.2.5'
 
 depends 'apt'
 depends 'java'
+depends 'chef-sugar'
 depends 'ohai'

--- a/recipes/_java.rb
+++ b/recipes/_java.rb
@@ -10,6 +10,6 @@
 if node['looker']['install_java']
   node.set['java']['oracle']['accept_oracle_download_terms'] = true
   node.set['java']['install_flavor'] = 'oracle'
-  node.set['java']['jdk_version'] = 7
+  node.set['java']['jdk_version'] = 8
   include_recipe('java')
 end

--- a/recipes/_ohai_plugin.rb
+++ b/recipes/_ohai_plugin.rb
@@ -6,18 +6,39 @@
 #
 # All rights reserved - Do Not Redistribute
 #
+include_recipe 'chef-sugar::default'
 
-ohai 'reload_looker' do
-  plugin 'looker'
-  action :nothing
-end
+at_compile_time do
+  ohai_plugins_path = '/etc/chef/ohai_plugins'
+  Ohai::Config[:plugin_path] << ohai_plugins_path
 
-template "#{node['ohai']['plugin_path']}/looker.rb" do
-  source 'plugins/looker.rb.erb'
-  owner 'root'
-  group node['root_group']
-  mode '0755'
-  notifies :reload, 'ohai[reload_looker]', :immediately
+  directory '/etc/chef' do
+    owner 'root'
+    group 'root'
+    mode '0755'
+    action :create
+    not_if { ::File.directory?('/etc/chef') }
+  end
+
+  directory ohai_plugins_path do
+    owner 'root'
+    group 'root'
+    mode '0755'
+    action :create
+  end
+
+  ohai 'reload_looker' do
+    plugin 'looker'
+    action :nothing
+  end
+
+  template "#{ohai_plugins_path}/looker.rb" do
+    source 'plugins/looker.rb.erb'
+    owner 'root'
+    group node['root_group']
+    mode '0755'
+    notifies :reload, 'ohai[reload_looker]', :immediately
+  end
 end
 
 include_recipe 'ohai::default'

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -12,7 +12,7 @@ end
 
 require 'ohai'
 
-PLUGIN_PATH = '/etc/chef/ohai_plugins'
+PLUGIN_PATH = '/etc/chef/ohai_plugins'.freeze
 Ohai::Config[:plugin_path] << PLUGIN_PATH
 o = Ohai::System.new
 o.all_plugins


### PR DESCRIPTION
On Friday Looker was upgraded to 3.52 which only supports JDK 8+, as a result Looker failed to start. We should default to JDK8. This also fixes ohai related fails.